### PR TITLE
New optional characters for Datepicker format

### DIFF
--- a/projects/angular-md/src/lib/datepicker/README.md
+++ b/projects/angular-md/src/lib/datepicker/README.md
@@ -68,6 +68,8 @@ import { DateLocale } from 'md2';
 | `firstDayOfWeek` | `number` | The first day of the week. Sunday = 0, Monday = 1, etc. |
 
 ### Date Format
+everything that is written inside `{` and `}` is treated as an optional input. Optionals will be nulled as input.  
+`format="dd.MM.y{ HH:mm}"` will accept `30.12.2018` and will display `30.12.2018 00:00`  
 
 | COMPONENT | SYMBOL | NARROW | SHORT FORM | LONG FORM        | NUMERIC | 2-DIGIT |
 | --------- | ------ | ------ | ---------- | ---------------- | ------- | ------- |

--- a/projects/angular-md/src/lib/datepicker/date-util.ts
+++ b/projects/angular-md/src/lib/datepicker/date-util.ts
@@ -112,6 +112,10 @@ export class DateUtil {
         } else if (/[NnaA]/.test(placeholderChar)) {
           indexMap[reIndex++] = [placeholderChar, param && param.split(',')];
           return '([a-zA-Z\\u0080-\\u1fff]+)';
+        } else if (placeholderChar == '{') {
+          return '(';
+        } else if (placeholderChar == '}') {
+          return ')?';
         } else if (/w/i.test(placeholderChar)) {
           return '[a-zA-Z\\u0080-\\u1fff]+';
         } else if (/\s/.test(placeholderChar)) {
@@ -158,8 +162,9 @@ export class DateUtil {
         }
       }
     }
-    let d = new Date(ctorArgs[0], ctorArgs[1], ctorArgs[2], ctorArgs[3], ctorArgs[4],
-      ctorArgs[5], ctorArgs[6]);
+
+    let d = new Date(ctorArgs[0] || 0, ctorArgs[1] || 0, ctorArgs[2] || 0, ctorArgs[3] || 0, ctorArgs[4] || 0,
+      ctorArgs[5] || 0, ctorArgs[6] || 0);
     return d;
   }
 

--- a/projects/angular-md/src/lib/datepicker/datepicker.ts
+++ b/projects/angular-md/src/lib/datepicker/datepicker.ts
@@ -403,6 +403,14 @@ export class Md2Datepicker implements OnDestroy, ControlValueAccessor {
 
     let format = this.format;
 
+    /* Special Optional Character */
+    if (format.indexOf('{') > -1) {
+      format = format.replace('{', '');
+    }
+    if (format.indexOf('}') > -1) {
+      format = format.replace('}', '');
+    }
+
     /* Years */
     if (format.indexOf('yy') > -1) {
       format = format.replace('yy', ('00' + this._util.getYear(date)).slice(-2));

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -17,4 +17,4 @@
     <h2><a target="_blank" rel="noopener" href="https://blog.angular.io/">Angular blog</a></h2>
   </li>
 </ul>
-<md2-datepicker type="datetime" placeholder="Datetime Demo" mode="auto" [displayWeek]="true"></md2-datepicker>
+<md2-datepicker type="datetime" placeholder="Datetime Demo" mode="auto" [displayWeek]="true" format="dd.MM.y{ HH:mm}"></md2-datepicker>


### PR DESCRIPTION
### Date Format
everything that is written inside `{` and `}` is treated as an optional input. Optionals will be nulled as input.  
`format="dd.MM.y{ HH:mm}"` will accept `30.12.2018` and will display `30.12.2018 00:00`  
