### PR TITLE
DOCUMENT has to be imported from @angular/common

### DIFF
--- a/projects/angular-md/src/lib/core/common-behaviors/common-module.ts
+++ b/projects/angular-md/src/lib/core/common-behaviors/common-module.ts
@@ -1,5 +1,5 @@
 import {NgModule, InjectionToken, Optional, Inject, isDevMode} from '@angular/core';
-import {DOCUMENT} from '@angular/platform-browser';
+import {DOCUMENT} from '@angular/common';
 import {CompatibilityModule} from '../compatibility/compatibility';
 
 


### PR DESCRIPTION
DOCUMENT has to be imported from @angular/common to make your project compatible with Angular 8. This change does not affect compatibility with Angular 6.